### PR TITLE
envoy.code.check(0.4.1): Use BUILD file for fuzz check.

### DIFF
--- a/envoy.code.check/envoy/code/check/abstract/extensions.py
+++ b/envoy.code.check/envoy/code/check/abstract/extensions.py
@@ -21,9 +21,9 @@ from envoy.code.check import abstract, exceptions, interface, typing
 logger = logging.getLogger(__name__)
 
 
-FILTER_NAMES_PATTERN = "NetworkFilterNames::get()"
+FILTER_NAMES_PATTERN = "envoy\\.filters\\.network"
 FUZZ_TEST_PATH = (
-    "test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc")
+    "test/extensions/filters/network/common/fuzz/BUILD")
 METADATA_PATH = "source/extensions/extensions_metadata.yaml"
 METADATA_ONLY_EXTENSIONS = (
     "envoy.filters.network.envoy_mobile_http_connection_manager", )
@@ -108,11 +108,11 @@ class AExtensionsCheck(abstract.ACodeCheck, metaclass=abstracts.Abstraction):
 
     @property
     def fuzzed_count(self) -> int:
-        # Hack-ish! We only search the first 50 lines to capture the filters
-        # in `filterNames()`.
+        # Hack-ish! We only search the first 60 lines to capture the filters
+        # in `READFILTER_FUZZ_FILTERS`.
         return len(
             self.fuzzed_filter_names_re.findall(
-                "".join(self.fuzz_test_path.read_text().splitlines()[:50])))
+                "".join(self.fuzz_test_path.read_text().splitlines()[:60])))
 
     @cached_property
     def fuzzed_filter_names_re(self) -> Pattern:

--- a/envoy.code.check/tests/test_abstract_extensions.py
+++ b/envoy.code.check/tests/test_abstract_extensions.py
@@ -289,7 +289,7 @@ def test_extensions_fuzzed_count(iters, patches):
         (m_path.return_value.read_text
                .return_value.splitlines
                .return_value.__getitem__.call_args)
-        == [(slice(None, 50), ), {}])
+        == [(slice(None, 60), ), {}])
     assert "fuzzed_count" not in checker.__dict__
 
 


### PR DESCRIPTION
Use the BUILD file in the network_readfilter_fuzz_test check to learn about the mandatory filters.

Mandatory changes for [#27373](https://github.com/envoyproxy/envoy/pull/27373). 

In PR 27373 the way filters for the network_readfilter_fuzz_test are specified, changed to a list in the BUILD-file. This patch reflects these changes.

Note, I am new to the `toolshed` and haven't found any guide on how to submit.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>