### PR TITLE
bazel: Add clang tidy aspect/target

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,5 @@
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("//:macros.bzl", "json_data")
 load("//:versions.bzl", "VERSIONS")
 
 json_data(

--- a/bazel/format/clang_tidy/.clang-tidy
+++ b/bazel/format/clang_tidy/.clang-tidy
@@ -1,0 +1,11 @@
+UseColor: true
+
+Checks: >
+    bugprone-*,
+    cppcoreguidelines-*,
+    google-*,
+    performance-*,
+
+HeaderFilterRegex: ".*"
+
+WarningsAsErrors: "*"

--- a/bazel/format/clang_tidy/BUILD
+++ b/bazel/format/clang_tidy/BUILD
@@ -1,0 +1,42 @@
+filegroup(
+    name = "config_default",
+    srcs = [
+        ".clang-tidy",
+        # '//example:clang_tidy_config', # add package specific configs if needed
+    ],
+)
+
+label_flag(
+    name = "config",
+    build_setting_default = ":config_default",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "executable_default",
+    srcs = [],  # empty list: system clang-tidy
+)
+
+label_flag(
+    name = "executable",
+    build_setting_default = ":executable_default",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "additional_deps_default",
+    srcs = [],
+)
+
+label_flag(
+    name = "additional_deps",
+    build_setting_default = ":additional_deps_default",
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "clang_tidy",
+    srcs = ["run_clang_tidy.sh"],
+    data = [":config"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/format/clang_tidy/clang_tidy.bzl
+++ b/bazel/format/clang_tidy/clang_tidy.bzl
@@ -1,0 +1,179 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _run_tidy(
+        ctx,
+        wrapper,
+        exe,
+        additional_deps,
+        config,
+        flags,
+        compilation_context,
+        infile,
+        discriminator):
+    inputs = depset(
+        direct = (
+            [infile, config] +
+            additional_deps.files.to_list() +
+            ([exe.files_to_run.executable] if exe.files_to_run.executable else [])
+        ),
+        transitive = [compilation_context.headers],
+    )
+
+    args = ctx.actions.args()
+
+    # specify the output file - twice
+    outfile = ctx.actions.declare_file(
+        "bazel_clang_tidy_" + infile.path + "." + discriminator + ".clang-tidy.yaml",
+    )
+
+    # this is consumed by the wrapper script
+    if len(exe.files.to_list()) == 0:
+        args.add("clang-tidy")
+    else:
+        args.add(exe.files_to_run.executable)
+
+    args.add(outfile.path)  # this is consumed by the wrapper script
+
+    args.add(config.path)
+
+    args.add("--export-fixes", outfile.path)
+
+    args.add("--quiet")
+
+    # add source to check
+    args.add(infile.path)
+
+    # start args passed to the compiler
+    args.add("--")
+
+    # add args specified by the toolchain, on the command line and rule copts
+    args.add_all(flags)
+
+    # add defines
+    for define in compilation_context.defines.to_list():
+        args.add("-D" + define)
+
+    for define in compilation_context.local_defines.to_list():
+        args.add("-D" + define)
+
+    # add includes
+    for i in compilation_context.framework_includes.to_list():
+        args.add("-F" + i)
+
+    for i in compilation_context.includes.to_list():
+        args.add("-I" + i)
+
+    args.add_all(compilation_context.quote_includes.to_list(), before_each = "-iquote")
+
+    args.add_all(compilation_context.system_includes.to_list(), before_each = "-isystem")
+
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [outfile],
+        executable = wrapper,
+        arguments = [args],
+        mnemonic = "ClangTidy",
+        use_default_shell_env = True,
+        progress_message = "Run clang-tidy on {}".format(infile.short_path),
+    )
+    return outfile
+
+def _rule_sources(ctx):
+    def check_valid_file_type(src):
+        """
+        Returns True if the file type matches one of the permitted srcs file types for C and C++ header/source files.
+        """
+        permitted_file_types = [
+            ".c", ".cc", ".cpp", ".cxx", ".c++", ".C", ".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".H",
+        ]
+        for file_type in permitted_file_types:
+            if src.basename.endswith(file_type):
+                return True
+        return False
+
+    srcs = []
+    if hasattr(ctx.rule.attr, "srcs"):
+        for src in ctx.rule.attr.srcs:
+            srcs += [src for src in src.files.to_list() if src.is_source and check_valid_file_type(src)]
+    return srcs
+
+def _toolchain_flags(ctx, action_name = ACTION_NAMES.cpp_compile):
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+    compile_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        user_compile_flags = ctx.fragments.cpp.cxxopts + ctx.fragments.cpp.copts,
+    )
+    flags = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = action_name,
+        variables = compile_variables,
+    )
+    return flags
+
+def _safe_flags(flags):
+    # Some flags might be used by GCC, but not understood by Clang.
+    # Remove them here, to allow users to run clang-tidy, without having
+    # a clang toolchain configured (that would produce a good command line with --compiler clang)
+    unsupported_flags = [
+        "-fno-canonical-system-headers",
+        "-fstack-usage",
+    ]
+
+    return [flag for flag in flags if flag not in unsupported_flags and not flag.startswith("--sysroot")]
+
+def _clang_tidy_aspect_impl(target, ctx):
+    # if not a C/C++ target, we are not interested
+    if not CcInfo in target:
+        return []
+
+    wrapper = ctx.attr._clang_tidy_wrapper.files_to_run
+    exe = ctx.attr._clang_tidy_executable
+    additional_deps = ctx.attr._clang_tidy_additional_deps
+    config = ctx.attr._clang_tidy_config.files.to_list()[0]
+    compilation_context = target[CcInfo].compilation_context
+
+    rule_flags = ctx.rule.attr.copts if hasattr(ctx.rule.attr, "copts") else []
+    safe_flags = {
+        ACTION_NAMES.cpp_compile: _safe_flags(_toolchain_flags(ctx, ACTION_NAMES.cpp_compile) + rule_flags),
+        ACTION_NAMES.c_compile: _safe_flags(_toolchain_flags(ctx, ACTION_NAMES.c_compile) + rule_flags),
+    }
+
+    srcs = _rule_sources(ctx)
+
+    outputs = [
+        _run_tidy(
+            ctx,
+            wrapper,
+            exe,
+            additional_deps,
+            config,
+            safe_flags[ACTION_NAMES.c_compile if src.extension == "c" else ACTION_NAMES.cpp_compile],
+            compilation_context,
+            src,
+            target.label.name,
+        )
+        for src in srcs
+    ]
+
+    return [
+        OutputGroupInfo(report = depset(direct = outputs)),
+    ]
+
+clang_tidy_aspect = aspect(
+    implementation = _clang_tidy_aspect_impl,
+    fragments = ["cpp"],
+    attrs = {
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        "_clang_tidy_wrapper": attr.label(default = Label("@envoy_toolshed//format/clang_tidy")),
+        "_clang_tidy_executable": attr.label(default = Label("@envoy_toolshed//format/clang_tidy:executable")),
+        "_clang_tidy_additional_deps": attr.label(default = Label("@envoy_toolshed//format/clang_tidy:additional_deps")),
+        "_clang_tidy_config": attr.label(default = Label("@envoy_toolshed//format/clang_tidy:config")),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/bazel/format/clang_tidy/run_clang_tidy.sh
+++ b/bazel/format/clang_tidy/run_clang_tidy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Usage: run_clang_tidy <OUTPUT> <CONFIG> [ARGS...]
+set -ue
+
+CLANG_TIDY_BIN=$1
+shift
+
+OUTPUT=$1
+shift
+
+CONFIG=$1
+shift
+
+# clang-tidy doesn't create a patchfile if there are no errors.
+# make sure the output exists, and empty if there are no errors,
+# so the build system will not be confused.
+touch $OUTPUT
+truncate -s 0 $OUTPUT
+
+# if $CONFIG is provided by some external workspace, we need to
+# place it in the current directory
+test -e .clang-tidy || ln -s -f $CONFIG .clang-tidy
+
+"${CLANG_TIDY_BIN}" "$@" |& grep -v "warnings generated" || :


### PR DESCRIPTION
this is currently an experimental feature - based on code from https://github.com/erenon/bazel_clang_tidy

currently it doesnt fail on errors, which allows it to continue rather than failing fast, it also doenst have any fix handling, so needs some work and general cleanups