### PR TITLE
`gh-actions/jq`: Allow empty input with default

### DIFF
--- a/gh-actions/jq/action.yml
+++ b/gh-actions/jq/action.yml
@@ -5,7 +5,7 @@ inputs:
   input:
     description: >
       Input string to mangle.
-    default: ""
+    default: "{}"
   decode:
     description: >
       Decode input from base64.

--- a/gh-actions/jq/modules/gfm.jq
+++ b/gh-actions/jq/modules/gfm.jq
@@ -6,11 +6,15 @@ def collapse:
   else
     .open = ""
   end
+  | if (.indent | type == "null") then
+      .indent = 2
+    else . end
+  | .indent as $indent
   | "
 <details \(.open)>
   <summary><b>\(.title)</b></summary>
 
-\(.content | str::indent(2))
+\(.content | str::indent($indent))
 
 </details>
 "


### PR DESCRIPTION
and fix for indent