### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
       working-directory: gh-actions/${{ matrix.name }}
     - run: npm run lint
       working-directory: gh-actions/${{ matrix.name }}


### PR DESCRIPTION
Let's hope it fixes "npmCommand not pinned by hash" security issue.
See [StackOverflow](https://stackoverflow.com/a/53325242) for more details.


Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
