### PR TITLE
Fix validating_code_block typecheck errors

### DIFF
--- a/envoy.docs.sphinx_runner/envoy/docs/sphinx_runner/ext/validating_code_block.py
+++ b/envoy.docs.sphinx_runner/envoy/docs/sphinx_runner/ext/validating_code_block.py
@@ -26,8 +26,7 @@ class ValidatingCodeBlock(CodeBlock):
     required_arguments = CodeBlock.required_arguments
     optional_arguments = CodeBlock.optional_arguments
     final_argument_whitespace = CodeBlock.final_argument_whitespace
-    option_spec = {"type-name": directives.unchanged}
-    option_spec.update(CodeBlock.option_spec)
+    CodeBlock.option_spec.update({'type-name': directives.unchanged})
 
     @cached_property
     def configs(self) -> Dict:


### PR DESCRIPTION
@phlax ,

I'm not extremely familiar with python so I prefer to check with you 
The test_extensions.py / test_ext_validating_code_block_vbc_constructor is still passing. 
I believe that fixes the typecheck error or am I missing something ?