### PR TITLE
`envoy.base.utils`: Use archive for fetching `objects.inv` in Project inventory

### DIFF
--- a/envoy.base.utils/envoy/base/utils/abstract/project/inventory.py
+++ b/envoy.base.utils/envoy/base/utils/abstract/project/inventory.py
@@ -19,7 +19,8 @@ INVENTORY_PATH_GLOB = "docs/inventories/v*.*/objects.inv"
 INVENTORY_PATH_FMT = "docs/inventories/v{minor_version}/objects.inv"
 INVENTORY_VERSIONS_PATH = "docs/versions.yaml"
 INVENTORY_URL_FMT = (
-    "https://www.envoyproxy.io/docs/envoy/v{version}/objects.inv")
+    "https://github.com/envoyproxy/archive/raw/main/"
+    "docs/envoy/v{version}/objects.inv")
 
 
 @abstracts.implementer(interface.IInventories)


### PR DESCRIPTION
Currently patch releasing is very slow due to the need to wait for the docs to be published to fetch inventory artefacts

This instead fetches from the archive which still relies on the docs actually being built so takes a little time but is significantly faster than waiting for the docs to be published on the website