### PR TITLE
`gh-actions/envoy/ci/request`: De-private wierdly private avatars

### DIFF
--- a/gh-actions/envoy/ci/request/action.yml
+++ b/gh-actions/envoy/ci/request/action.yml
@@ -228,7 +228,7 @@ runs:
           end
         | . * {"actor": {
                  name: $actor,
-                 icon: $event.sender.avatar_url},
+                 icon: $event.sender.avatar_url | gsub("\\?.*$"; "") | gsub("^https://private-"; "https://")},
                "message": $message,
                "started": ${{ inputs.started }},
                "target-branch": "${{ inputs.branch-name }}",


### PR DESCRIPTION
this should fix an issue where some users avatar has gone private and include a `jwt` which fails githubs secret scanning