### PR TITLE
v8: Make wee8 prebuilt a true drop-in for @v8//:wee8

### DIFF
--- a/bazel/MODULE.bazel
+++ b/bazel/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     bazel_compatibility = [">=7.2.1"],
 )
 
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/bazel/MODULE.bazel.lock
+++ b/bazel/MODULE.bazel.lock
@@ -15,7 +15,8 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
     "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/MODULE.bazel": "c43c16ca2c432566cdb78913964497259903ebe8fb7d9b57b38e9f1425b427b8",
     "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
+    "https://bcr.bazel.build/modules/abseil-cpp/20260107.1/MODULE.bazel": "e33b3801443f5fd64465262084534115db76363df13d2168a42bbfacc747be81",
+    "https://bcr.bazel.build/modules/abseil-cpp/20260107.1/source.json": "7a9a88969b1e79268cf613728ca8ff8fa4bc4b1a9abee9ec1fb5f113ca751971",
     "https://bcr.bazel.build/modules/abseil-py/2.1.0/MODULE.bazel": "5ebe5bf853769c65707e5c28f216798f7a4b1042015e6a36e6d03094d94bec8a",
     "https://bcr.bazel.build/modules/abseil-py/2.1.0/source.json": "0e8fc4f088ce07099c1cd6594c20c7ddbb48b4b3c0849b7d94ba94be88ff042b",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
@@ -172,6 +173,7 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.15.1/MODULE.bazel": "c2c60d26c79fda484acb95cdbec46e89d6b28b4845cb277160ce1e0c8622bb88",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.15.1/source.json": "a161811a63ba8a859086da3b7ff3ad04f2e9c255d7727b41087103fc0eb22f55",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
@@ -305,8 +307,8 @@
   "moduleExtensions": {
     "//compile:extensions.bzl%libcxx_extension": {
       "general": {
-        "bzlTransitiveDigest": "BTuyHAmPV6RLjmwYvHgt5sqEor5vYxcSNJW+rLVnLU4=",
-        "usagesDigest": "RN4CLPdbGThKbAP902x5jh5QAjMcWrWkUrFVQZo2yX8=",
+        "bzlTransitiveDigest": "G/GH44cjY6wlnZEwWmvHkcNdAdZzFZ+1txwMfbYffZ4=",
+        "usagesDigest": "y4Q8/OHUodqeqYFwT/Dh6kGVc3RcORSJIuy06M/HAsY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -333,8 +335,8 @@
     },
     "//compile:extensions.bzl%libcxx_libs_extension": {
       "general": {
-        "bzlTransitiveDigest": "xq4mUY6BVQnnWqOzX/XORJO7GVFn1zwGLk82OjEZLF4=",
-        "usagesDigest": "RIkUSFV80yIb144efeISdWNXBS3AN1AgryPVfPEqm7E=",
+        "bzlTransitiveDigest": "G/GH44cjY6wlnZEwWmvHkcNdAdZzFZ+1txwMfbYffZ4=",
+        "usagesDigest": "WGLlE+LyBlwJgqcy7T1SulsGcIEfdJP7sOvnAUOVhN4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -342,7 +344,7 @@
           "libcxx_libs_aarch64": {
             "repoRuleId": "@@//compile:libcxx_libs.bzl%libcxx_libs",
             "attributes": {
-              "version": "0.2.8",
+              "version": "0.2.9",
               "sha256": "b3bd8dfc1c250d5c2c36de174138ffef9754402b33e54abe9b5efb25982fa2f7",
               "arch": "aarch64"
             }
@@ -350,7 +352,7 @@
           "libcxx_libs_x86_64": {
             "repoRuleId": "@@//compile:libcxx_libs.bzl%libcxx_libs",
             "attributes": {
-              "version": "0.2.8",
+              "version": "0.2.9",
               "sha256": "e40f39338ffe561dfa26541557c9e548fc7760db9d99f7b6c5de237b725482aa",
               "arch": "x86_64"
             }
@@ -361,8 +363,8 @@
     },
     "//compile:extensions.bzl%llvm_minimal_build_extension": {
       "general": {
-        "bzlTransitiveDigest": "BTuyHAmPV6RLjmwYvHgt5sqEor5vYxcSNJW+rLVnLU4=",
-        "usagesDigest": "J/GulDAMOVsY4WAHN2G2r2pj5al4Kp1B7U+FYemKFmQ=",
+        "bzlTransitiveDigest": "G/GH44cjY6wlnZEwWmvHkcNdAdZzFZ+1txwMfbYffZ4=",
+        "usagesDigest": "NCpK+4w39uxhSXpaGA4yQ6/z003ZRGW4JrTDl1gySFk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -400,8 +402,8 @@
     },
     "//compile:extensions.bzl%llvm_minimal_extension": {
       "general": {
-        "bzlTransitiveDigest": "xq4mUY6BVQnnWqOzX/XORJO7GVFn1zwGLk82OjEZLF4=",
-        "usagesDigest": "Q+CKSP0adR7YFwQRyGmwMLzUFi/fI4mpjnKPqgG4qPE=",
+        "bzlTransitiveDigest": "G/GH44cjY6wlnZEwWmvHkcNdAdZzFZ+1txwMfbYffZ4=",
+        "usagesDigest": "/8xOPYq4umt9kQm/PPSkVQfPK7VDDYgWt4XUvkXSz8A=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -409,7 +411,7 @@
           "llvm_minimal_linux_x64": {
             "repoRuleId": "@@//compile:llvm_minimal.bzl%llvm_minimal_repo",
             "attributes": {
-              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.8/llvm-minimal-22.1.8-Linux-X64.tar.zst",
+              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.9/llvm-minimal-22.1.8-Linux-X64.tar.zst",
               "sha256": "6cb4cca6df33be00c80fa1639062c973d1cafe4e7ad98a9b4bdf21bf9dec5806",
               "strip_prefix": "llvm-minimal-22.1.8-Linux-X64"
             }
@@ -417,7 +419,7 @@
           "llvm_minimal_linux_arm64": {
             "repoRuleId": "@@//compile:llvm_minimal.bzl%llvm_minimal_repo",
             "attributes": {
-              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.8/llvm-minimal-22.1.8-Linux-ARM64.tar.zst",
+              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.9/llvm-minimal-22.1.8-Linux-ARM64.tar.zst",
               "sha256": "9a6cc0a84d524342e578db739b04e8a3875adb40b38887e4e074661e925f8a9c",
               "strip_prefix": "llvm-minimal-22.1.8-Linux-ARM64"
             }
@@ -425,7 +427,7 @@
           "llvm_minimal_macos_arm64": {
             "repoRuleId": "@@//compile:llvm_minimal.bzl%llvm_minimal_repo",
             "attributes": {
-              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.8/llvm-minimal-22.1.8-macOS-ARM64.tar.zst",
+              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.9/llvm-minimal-22.1.8-macOS-ARM64.tar.zst",
               "sha256": "928e51aa7c97fbb8c5c50075118f4b36e36363b1a2c3af2dfef9aea1ef526ade",
               "strip_prefix": "llvm-minimal-22.1.8-macOS-ARM64"
             }
@@ -436,8 +438,8 @@
     },
     "//compile:extensions.bzl%llvm_toolchain_alias_extension": {
       "general": {
-        "bzlTransitiveDigest": "BTuyHAmPV6RLjmwYvHgt5sqEor5vYxcSNJW+rLVnLU4=",
-        "usagesDigest": "REJEYfkX35dncC7j7UXGSvs9/b3F7M2GxmHTa51bVOw=",
+        "bzlTransitiveDigest": "G/GH44cjY6wlnZEwWmvHkcNdAdZzFZ+1txwMfbYffZ4=",
+        "usagesDigest": "uWO75d9O0kcL3vMT7TyGSHvbrJIp0/gDyo9vXEEY5Zw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -445,24 +447,24 @@
           "llvm_minimal_linux_x64": {
             "repoRuleId": "@@//compile:llvm_minimal.bzl%llvm_minimal_repo",
             "attributes": {
-              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.7/llvm-minimal-22.1.8-Linux-X64.tar.zst",
-              "sha256": "3055f223cb27740e319412303c8298787b78062839d8809b88b13c4d6bcd82ca",
+              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.9/llvm-minimal-22.1.8-Linux-X64.tar.zst",
+              "sha256": "6cb4cca6df33be00c80fa1639062c973d1cafe4e7ad98a9b4bdf21bf9dec5806",
               "strip_prefix": "llvm-minimal-22.1.8-Linux-X64"
             }
           },
           "llvm_minimal_linux_arm64": {
             "repoRuleId": "@@//compile:llvm_minimal.bzl%llvm_minimal_repo",
             "attributes": {
-              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.7/llvm-minimal-22.1.8-Linux-ARM64.tar.zst",
-              "sha256": "b00ea67259e613907da30cb5d8290192b54ab656f4759ace6794f3e10de1d0ed",
+              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.9/llvm-minimal-22.1.8-Linux-ARM64.tar.zst",
+              "sha256": "9a6cc0a84d524342e578db739b04e8a3875adb40b38887e4e074661e925f8a9c",
               "strip_prefix": "llvm-minimal-22.1.8-Linux-ARM64"
             }
           },
           "llvm_minimal_macos_arm64": {
             "repoRuleId": "@@//compile:llvm_minimal.bzl%llvm_minimal_repo",
             "attributes": {
-              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.7/llvm-minimal-22.1.8-macOS-ARM64.tar.zst",
-              "sha256": "04a2ac21e89a42dba532509ee67c246b71ec8a15c6cef0f2d63e349fb120934c",
+              "url": "https://github.com/envoyproxy/toolshed/releases/download/bins-v0.2.9/llvm-minimal-22.1.8-macOS-ARM64.tar.zst",
+              "sha256": "928e51aa7c97fbb8c5c50075118f4b36e36363b1a2c3af2dfef9aea1ef526ade",
               "strip_prefix": "llvm-minimal-22.1.8-macOS-ARM64"
             }
           },
@@ -480,8 +482,8 @@
     },
     "//sysroot:extensions.bzl%macos_sysroot_build_extension": {
       "general": {
-        "bzlTransitiveDigest": "8mBbKuC9X+dVsJfKM+AgJFJoBBNzOGVJZxdCfSxLqq0=",
-        "usagesDigest": "upEStvIodWzxrsjRav9f31RuWmY7tAcR2XsgIoulj9k=",
+        "bzlTransitiveDigest": "FOSmmvc22vA+YeVHySGYbJvOJk9fO2s5NCh3/JxObds=",
+        "usagesDigest": "DCjVA8KsZTFyZYgD4DlFoO09sE28RLoFZBbgbyGe5IA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -512,8 +514,8 @@
     },
     "//sysroot:extensions.bzl%sysroot_extension": {
       "general": {
-        "bzlTransitiveDigest": "PF3oNYod5GkYA2DCs46F5a8BkZbFeJLt6wv1gZYWk30=",
-        "usagesDigest": "QuvSVj2nF2HTzMnymPuZHLvRfdfCftaYggoWoY1FCyo=",
+        "bzlTransitiveDigest": "FOSmmvc22vA+YeVHySGYbJvOJk9fO2s5NCh3/JxObds=",
+        "usagesDigest": "1Sb8DWa26TwIYmcUvz/HBQFKH+RC3PrE6martwJ5IW0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -521,8 +523,8 @@
           "sysroot_linux_amd64": {
             "repoRuleId": "@@//sysroot:sysroot.bzl%sysroot",
             "attributes": {
-              "version": "0.2.8",
-              "sha256": "63b6ff808f87b03fefb695941906e419b8f88f8e27150b3e2007dbc0012b78a8",
+              "version": "0.2.9",
+              "sha256": "d19427a63d942159dfbb50dab53354ec42c25bab4d21d38ea2ed6a5244adbaff",
               "arch": "amd64",
               "glibc_version": "2.31",
               "stdcc_version": "13"
@@ -531,8 +533,8 @@
           "sysroot_linux_arm64": {
             "repoRuleId": "@@//sysroot:sysroot.bzl%sysroot",
             "attributes": {
-              "version": "0.2.8",
-              "sha256": "8f3847a6a5147dd5c13c92914f009c38792dbe82196a77187bc284b937c0cc6c",
+              "version": "0.2.9",
+              "sha256": "cd8315000d016af8f66ffe14ce9f36ccf51d0665906353ed6edfe0f62aef5461",
               "arch": "arm64",
               "glibc_version": "2.31",
               "stdcc_version": "13"
@@ -544,8 +546,8 @@
     },
     "//v8:extensions.bzl%wee8_prebuilt_extension": {
       "general": {
-        "bzlTransitiveDigest": "gHfQ5XAztuVD/qC/C7BjzVSDMcAdCb/wGta8N4MEJ0E=",
-        "usagesDigest": "qtgEPyqlaewbvM4bt1SZIGrtGJ58GcpfmXLpk1VMdL8=",
+        "bzlTransitiveDigest": "gsXYB+H4d98wucAB/t4R1FvkLoUxhsKECV/2O2Zgq6k=",
+        "usagesDigest": "7Sk9Z5s6Ry8BI/L+Csf8i6W1AJRSTlQmtJZ9m23Qve8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -553,8 +555,8 @@
           "wee8_prebuilt_x86_64": {
             "repoRuleId": "@@//v8:wee8_prebuilt.bzl%wee8_prebuilt",
             "attributes": {
-              "version": "0.2.8",
-              "sha256": "96e3146e68dc2d1ae299ba5845c2a9edb2cb3dfe64fbedbcc77b339a95061d80",
+              "version": "0.2.9",
+              "sha256": "4694878d524d11c4d59a515657d2d0693aaa4907c3a30f1767b78b66bf260275",
               "arch": "x86_64",
               "stdlib": "libcxx"
             }
@@ -562,8 +564,8 @@
           "wee8_prebuilt_x86_64_libstdcxx": {
             "repoRuleId": "@@//v8:wee8_prebuilt.bzl%wee8_prebuilt",
             "attributes": {
-              "version": "0.2.8",
-              "sha256": "874a66ebf631f13189b30179fceb232fabde59f8ca6a47b6a1a82d04db9afeee",
+              "version": "0.2.9",
+              "sha256": "353a031e31cddd57237a15d52c3f7b0bae6dfb5048605e72792bcb1baa6abd60",
               "arch": "x86_64",
               "stdlib": "libstdcxx"
             }
@@ -571,8 +573,8 @@
           "wee8_prebuilt_aarch64": {
             "repoRuleId": "@@//v8:wee8_prebuilt.bzl%wee8_prebuilt",
             "attributes": {
-              "version": "0.2.8",
-              "sha256": "cacd8cf4b17bba81dc2a506b21c7314fcedb0fc6507c581dbc6c4827a9994cf5",
+              "version": "0.2.9",
+              "sha256": "3a8619a5e0fd55f5bffe87621ad652a7739c96e8a8c3afa11d1d2412c4898136",
               "arch": "aarch64",
               "stdlib": "libcxx"
             }

--- a/bazel/v8/wee8_prebuilt.bzl
+++ b/bazel/v8/wee8_prebuilt.bzl
@@ -8,6 +8,37 @@ WEE8_STDLIBS = [
     "libstdcxx",
 ]
 
+# V8 build-time defines that the source @v8//:wee8 target propagates to its
+# consumers (captured via `bazel aquery` on a V8 CppCompile action). These are
+# ABI-affecting and/or gate public V8 headers (e.g. V8_ENABLE_WEBASSEMBLY guards
+# src/wasm/c-api.h), so the prebuilt must re-expose them or consumers compiling
+# against libwee8.a (e.g. proxy_wasm_cpp_host's v8.cc) get header errors / ABI
+# skew. Arch-specific target define is appended per-repo (see _WEE8_ARCH_DEFINE).
+_WEE8_COMMON_DEFINES = [
+    "GOOGLE3",
+    "V8_ADVANCED_BIGINT_ALGORITHMS",
+    "V8_CONCURRENT_MARKING",
+    "V8_DEPRECATION_WARNINGS",
+    "V8_ENABLE_CONTINUATION_PRESERVED_EMBEDDER_DATA",
+    "V8_ENABLE_EXTENSIBLE_RO_SNAPSHOT",
+    "V8_ENABLE_LAZY_SOURCE_POSITIONS",
+    "V8_ENABLE_MAGLEV",
+    "V8_ENABLE_SPARKPLUG",
+    "V8_ENABLE_TURBOFAN",
+    "V8_ENABLE_UNDEFINED_DOUBLE",
+    "V8_ENABLE_WEBASSEMBLY",
+    "V8_HAVE_TARGET_OS",
+    "V8_IMMINENT_DEPRECATION_WARNINGS",
+    "V8_TARGET_OS_LINUX",
+    "V8_TLS_USED_IN_LIBRARY",
+    "V8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64",
+]
+
+_WEE8_ARCH_DEFINE = {
+    "x86_64": "V8_TARGET_ARCH_X64",
+    "aarch64": "V8_TARGET_ARCH_ARM64",
+}
+
 _WEE8_BUILD = """\
 package(default_visibility = ["//visibility:public"])
 
@@ -28,6 +59,20 @@ filegroup(
     srcs = ["lib/libwee8.a"],
 )
 
+# The wasm C-API public headers are #included as "wasm-api/wasm.hh", mirroring
+# the source @v8//:wee8 target's strip_include_prefix = "third_party" (scoped so
+# it does not put the rest of third_party/ on the include path).
+cc_library(
+    name = "wasm_c_api_headers",
+    hdrs = glob(
+        [
+            "third_party/wasm-api/*.h",
+            "third_party/wasm-api/*.hh",
+        ],
+    ),
+    strip_include_prefix = "third_party",
+)
+
 cc_library(
     name = "wee8",
     srcs = ["lib/libwee8.a"],
@@ -36,7 +81,18 @@ cc_library(
         ".",
         "include",
     ],
+    defines = [
+{defines}
+    ],
     linkstatic = True,
+    # abseil/icu are deliberately excluded from libwee8.a (consumers provide
+    # their own). Re-expose abseil's compile context (v8.cc #includes absl
+    # headers directly) and the wasm C-API headers so the prebuilt is a drop-in
+    # for the source @v8//:wee8.
+    deps = [
+        ":wasm_c_api_headers",
+        "@abseil-cpp//absl/strings:str_format",
+    ],
 )
 """
 
@@ -130,7 +186,12 @@ def _wee8_prebuilt_impl(ctx):
         )
         return
 
-    ctx.file("BUILD.bazel", _WEE8_BUILD)
+    defines = list(_WEE8_COMMON_DEFINES)
+    arch_define = _WEE8_ARCH_DEFINE.get(ctx.attr.arch)
+    if arch_define:
+        defines.append(arch_define)
+    defines_block = "\n".join(['        "%s",' % define for define in defines])
+    ctx.file("BUILD.bazel", _WEE8_BUILD.format(defines = defines_block))
 
 _ARCHES = ["x86_64", "aarch64"]
 


### PR DESCRIPTION
## What

Make the prebuilt `libwee8.a` `cc_library` (`@wee8_prebuilt_*//:wee8`) a true
drop-in for the source `@v8//:wee8` target, and pin abseil so the prebuilt is
ABI-compatible with Envoy.

Consumers that compile against the prebuilt (notably `proxy_wasm_cpp_host`'s
`src/v8/v8.cc`) previously hit header errors and ABI skew because the prebuilt
did not reproduce the compile context the source target propagates:

- **Missing abseil compile context** — `v8.cc` `#include`s `<absl/strings/str_format.h>`
  directly. Add `deps = ["@abseil-cpp//absl/strings:str_format"]`.
- **Missing V8 defines** — `V8_ENABLE_WEBASSEMBLY` (and friends) gate public V8
  headers (`src/wasm/c-api.h`) and are ABI-affecting. Re-expose the set the
  source target propagates via `_WEE8_COMMON_DEFINES`, with the arch target
  define appended per-repo (`_WEE8_ARCH_DEFINE`). Captured via
  `bazel aquery` on a V8 `CppCompile` action.
- **Missing wasm C-API include path** — headers are `#include`d as
  `"wasm-api/wasm.hh"`. Add a scoped `wasm_c_api_headers` `cc_library` mirroring
  the source target's `strip_include_prefix = "third_party"`.

- **Pin `abseil-cpp` to `20260107.1`** to match the version Envoy links against,
  so a CI-built `libwee8.a` references `absl::lts_20260107` rather than the
  `20250814` the v8 registry module pulls in transitively. Both are
  `compatibility_level = 1`, so MVS resolves to the max. Keep in sync with
  Envoy's `bazel/repository_locations.bzl` `abseil_cpp` version.

## Why

`libwee8.a` deliberately excludes abseil/icu (consumers provide their own). For
that to link, the prebuilt's abseil symbols must match the consumer's abseil
inline-namespace version. Envoy is on `20260107.1`; without this pin the prebuilt
carries `20250814` symbols and Envoy fails to link with undefined
`absl::lts_20250814::…` symbols.

## Testing

Verified end-to-end against a local Envoy `./ci/do_ci.sh dev` build consuming a
wee8 archive rebuilt against abseil `20260107.1`: the previously-undefined V8 and
`absl::lts_*` symbols are gone and the `proxy_wasm_cpp_host` v8 target links
cleanly.

## Follow-up (required before this fully ships)

The published `bins-v0.2.9` wee8 tarballs (whose SHAs are in `versions.bzl`) were
built against abseil `20250814`. A new bins release must **rebuild all wee8
variants against `20260107.1`** and refresh `wee8_sha256`, otherwise a consumer
on `20260107.1` still downloads a `20250814` archive and hits the mismatch. This
PR is the source-side prerequisite for that rebuild.
