### PR TITLE
v8: fall back to from-source wee8 on aarch64 (prebuilt segfaults)

### DIFF
--- a/bazel/v8/BUILD
+++ b/bazel/v8/BUILD
@@ -66,7 +66,12 @@ alias(
         ":linux_x86_64": "@%s//:wee8" % wee8_prebuilt_repo_name("x86_64"),
         # This does not currently work as it would require x-libs similar to how we provision llvm
         # ":linux_aarch64_gcc": "@%s//:wee8" % wee8_prebuilt_repo_name("aarch64", "libstdcxx"),
-        ":linux_aarch64": "@%s//:wee8" % wee8_prebuilt_repo_name("aarch64"),
+        # The aarch64 prebuilt is currently runtime-broken: the cross-compiled
+        # libwee8.a makes wee8_compile_tool segfault when compiling .wasm fixtures
+        # (seen in Envoy arm64 release CI). Fall back to building V8 from source on
+        # aarch64 until the artifact is repaired; then restore the line below:
+        #   ":linux_aarch64": "@%s//:wee8" % wee8_prebuilt_repo_name("aarch64"),
+        ":linux_aarch64": "@v8//:wee8",
         "//conditions:default": "@v8//:wee8",
     }),
     tags = ["manual"],


### PR DESCRIPTION
## Summary

The cross-compiled **aarch64** prebuilt `libwee8.a` is currently runtime-broken: it makes `wee8_compile_tool` **segfault** when compiling `.wasm` fixtures. This surfaces in Envoy's **arm64 release CI**:

```
ERROR: test/extensions/common/wasm/test_data/BUILD:13:17: Action
  test/extensions/common/wasm/test_data/test_rust.wasm failed:
  (Segmentation fault): wee8_compile_tool failed
  bazel-out/aarch64-opt/bin/test/tools/wee8_compile/wee8_compile_tool ...
```

There is no downstream lever to scope a fallback: arm64 release runs natively under the *same* `--config` as x64, so the consumer (Envoy) has no per-cpu `.bazelrc` hook to redirect the engine only on aarch64. The fix has to live here.

## Change

Point the `//v8:wee8` alias' `:linux_aarch64` case at `@v8//:wee8` (build V8 from source, like `//conditions:default`) until the aarch64 artifact is repaired. The x86_64 libcxx/libstdcxx prebuilts are unaffected. The prior line is preserved in a comment for easy restoration once the artifact is fixed.

## Verification

`bazel query --enable_bzlmod --noenable_workspace 'labels(actual, //v8:wee8)'` now resolves to:

```
@wee8_prebuilt_x86_64//:wee8
@wee8_prebuilt_x86_64_libstdcxx//:wee8
@v8//:wee8
```

— the aarch64 prebuilt is no longer referenced; aarch64 falls back to from-source.

## Follow-up

Repair the cross-compiled aarch64 `libwee8.a` so `wee8_compile_tool` runs correctly on arm64, then restore the commented `:linux_aarch64` prebuilt line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)