### PR TITLE
v8: fix cross-compiled aarch64 wee8 snapshot targeting wrong ISA (x86_64 blob in arm64 lib)

### DIFF
--- a/bazel/v8/wee8_package.bzl
+++ b/bazel/v8/wee8_package.bzl
@@ -29,6 +29,15 @@ _ARCH_PLATFORMS = {
     # ("aarch64", "libstdcxx"): "//platforms:linux_aarch64_libstdcxx",
 }
 
+# V8's mksnapshot/torque run as exec (build-host) tools but must emit code for
+# the target ISA, which V8 resolves from @v8//bazel/config:v8_target_cpu (else
+# mapping[--cpu]). We set only --platforms, not --cpu, so on an x86_64 host the
+# aarch64 build otherwise gets an x86_64 snapshot that segfaults on real arm64.
+_V8_TARGET_CPU = {
+    "x86_64": "x64",
+    "aarch64": "arm64",
+}
+
 # The transition sets the target platform only. Execution platforms are supplied
 # by config, not here:
 #
@@ -48,12 +57,16 @@ def _wee8_transition_impl(settings, attr):
         "//command_line_option:platforms": [
             _ARCH_PLATFORMS[(attr.arch, attr.stdlib)],
         ],
+        "@v8//bazel/config:v8_target_cpu": _V8_TARGET_CPU[attr.arch],
     }
 
 _wee8_transition = transition(
     implementation = _wee8_transition_impl,
     inputs = [],
-    outputs = ["//command_line_option:platforms"],
+    outputs = [
+        "//command_line_option:platforms",
+        "@v8//bazel/config:v8_target_cpu",
+    ],
 )
 
 _TRANSITION_ATTRS = {


### PR DESCRIPTION
## v8: fix the aarch64 wee8 prebuilt (x86_64 snapshot in an AArch64 library)

Supersedes #5177 (which only added the source fallback). This PR fixes the underlying build defect **and** keeps the interim fallback until a corrected artifact is released.

### Root cause
The published aarch64 `libwee8.a` embeds an **x86_64 builtins snapshot** inside an otherwise-correct AArch64 library. Every object member is clean AArch64, but the embedded blob `v8_Default_embedded_blob_code_` in `embedded.pic.o` is x86_64 machine code. On real arm64 hardware V8 finishes snapshot setup and jumps into x86_64 bytes on the first builtin call (while compiling the `.wasm` fixture) → `SIGSEGV`, no V8 `CHECK`/backtrace. This is the `wee8_compile_tool failed: (Segmentation fault)` in [envoyproxy/envoy#47108](https://github.com/envoyproxy/envoy/pull/47108) arm64 CI.

Why it shipped: the wee8 packaging transition set only `//command_line_option:platforms` for the target arch, not V8's `@v8//bazel/config:v8_target_cpu`. V8's `mksnapshot` runs as an *exec* (build-host) tool but emits code for the ISA its `v8_target_cpu_transition` resolves, which **falls back to `mapping[--cpu]` when that flag is `"none"` (the default)**. We never set `--cpu`, so on the x86_64 build host it resolved to `x64` and mksnapshot emitted an x86_64 embedded blob. The release pipeline's symbol-count / `.o`-arch checks don't inspect blob *content*, so it passed.

### Fix
Set `@v8//bazel/config:v8_target_cpu` on the wee8 transition to the target ISA (`aarch64→arm64`, `x86_64→x64`) so mksnapshot emits the correct arch.

### Validation (no arm64 hardware needed)
Rebuilt the aarch64 archive and disassembled `v8_Default_embedded_blob_code_` in the fresh `embedded.pic.o`:

| signature | before (published) | after (this PR) |
|---|---|---|
| AArch64 `ret` (`c0 03 5f d6`) | 0 | 2,638 |
| AArch64 `stp x29,x30` prologue | 0 | 4,162 |
| AArch64 `nop` on 4-byte grid | 0 | 6,435 |
| x86 REX.W (`0x48`) byte share | 4.3% | 0.26% (incidental) |

First bytes now decode as a textbook AArch64 epilogue (`ldp x29,x30,[sp],#16 ; ret`), versus an x86-64 XMM-save prologue before.

### Sequencing
The build fix corrects **future** artifacts; the currently-published prebuilt (`bins-v0.2.12`) still contains the broken snapshot. So the aarch64 alias keeps the from-source fallback here. Once a release is cut with the corrected artifact and `//:versions.bzl` is bumped, a follow-up can restore `":linux_aarch64"` to the prebuilt.
