### PR TITLE
bazel: fix sanitiaizer header excludes

### DIFF
--- a/bazel/compile/BUILD
+++ b/bazel/compile/BUILD
@@ -140,6 +140,12 @@ cmake(
     working_directory = "runtimes",
 )
 
+filegroup(
+    name = "libcxx_msan_headers",
+    srcs = [":libcxx_msan"],
+    output_group = "include",
+)
+
 pkg_files(
     name = "msan_libs_files",
     srcs = [":libcxx_msan"],
@@ -148,10 +154,7 @@ pkg_files(
         ":macos_build": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    excludes = [
-        "**/*.h",
-        "**/include/**",
-    ],
+    excludes = [":libcxx_msan_headers"],
     prefix = "msan-libs-x86_64/lib",
     strip_prefix = ".",
 )
@@ -168,6 +171,12 @@ pkg_tar(
     package_file_name = "msan-llvm%s-x86_64.tar.xz" % VERSIONS["llvm"],
 )
 
+filegroup(
+    name = "libcxx_tsan_headers",
+    srcs = [":libcxx_tsan"],
+    output_group = "include",
+)
+
 pkg_files(
     name = "tsan_libs_files",
     target_compatible_with = select({
@@ -176,10 +185,7 @@ pkg_files(
         "//conditions:default": [],
     }),
     srcs = [":libcxx_tsan"],
-    excludes = [
-        "**/*.h",
-        "**/include/**",
-    ],
+    excludes = [":libcxx_tsan_headers"],
     prefix = "tsan-libs-x86_64/lib",
     strip_prefix = ".",
 )


### PR DESCRIPTION
`pkg_files.excludes` takes file labels, not globs, so currently the patterns are not taking effect. This is relatively harmless making downstream downloads get a few more files, envoy doesn't consume the header files when present anyways. But it also seems to trigger a Bazel bug on Windows causing a crash during analysis

/cc @yanavlasov

```
[94](https://github.com/curioswitch/py-envoy-server/actions/runs/34103783638/job/101684026172#step:3:413)
  FATAL: bazel crashed due to an internal error. Printing stack trace:
  java.lang.RuntimeException: Unrecoverable error while evaluating node '[D:/_bazel/external/envoy_toolshed+]/[compile/**]' (requested by nodes 'FILE:[D:/_bazel/external/envoy_toolshed+]/[compile/**]')
  	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:547)
  	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:435)
  	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
  	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
  	at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(Unknown Source)
  	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
  	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
  	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
  	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
  Caused by: java.nio.file.InvalidPathException: Illegal char <*> at index 43: D:\_bazel\external\envoy_toolshed+\compile\**
  	at java.base/sun.nio.fs.WindowsPathParser.normalize(Unknown Source)
  	at java.base/sun.nio.fs.WindowsPathParser.parse(Unknown Source)
  	at java.base/sun.nio.fs.WindowsPathParser.parse(Unknown Source)
  	at java.base/sun.nio.fs.WindowsPath.parse(Unknown Source)
  	at java.base/sun.nio.fs.WindowsFileSystem.getPath(Unknown Source)
  	at java.base/java.io.File.toPath(Unknown Source)
  	at com.google.devtools.build.lib.windows.WindowsFileSystem.getAttribs(WindowsFileSystem.java:283)
  	at com.google.devtools.build.lib.windows.WindowsFileSystem.stat(WindowsFileSystem.java:155)
  	at com.google.devtools.build.lib.vfs.JavaIoFileSystem.statIfFound(JavaIoFileSystem.java:511)
  	at com.google.devtools.build.lib.vfs.Path.statIfFound(Path.java:335)
  	at com.google.devtools.build.lib.vfs.SyscallCache$1.statIfFound(SyscallCache.java:47)
  	at com.google.devtools.build.lib.actions.FileStateValue.create(FileStateValue.java:86)
  	at com.google.devtools.build.lib.skyframe.FileStateFunction.compute(FileStateFunction.java:67)
  	at com.google.devtools.build.lib.skyframe.FileStateFunction.compute(FileStateFunction.java:35)
  	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:467)
  	... 8 more
```